### PR TITLE
Support for packagist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /vendor/
+.idea
+composer.lock
+composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
-.idea
+/build/
+/.idea/
 composer.lock
 composer.phar

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 php-openssl-cryptor
 ===================
 
-Description
------------
-Simple to use class for encrypting/decrypting using the PHP Openssl library. 
+Simple to use class for encrypting/decrypting using the PHP Openssl library.
+
+## Description
 
 The Cryptor class supports arbitrary encryption and key hashing algorithms, along
 with raw, base64 and hex encoding of the encrypted data. Static convenience methods
@@ -12,3 +12,29 @@ flexibility. The default uses aes-256-ctr to avoid the need for padding and the 
 issues. Unfortunately GCM cannot be used as the PHP openssl module does not provide 
 a way to retrieve the GCM tag. This is proposed to be remedied in PHP 7.1 when 
 associated data can be retrieved.
+
+## Install
+
+Require this library through composer:
+
+```
+composer require pensiero/php-openssl-cryptor
+```
+
+
+## Example
+
+```php
+use OpensslCryptor\Cryptor;
+
+$data = 'Good things come in small packages.';
+$key = '9901:io=[<>602vV03&Whb>9J&M~Oq';
+
+$encrypted = Cryptor::Encrypt($data, $key);
+
+echo "'$data' (" . strlen($data) . ") => '$encrypted'\n\n";
+
+$decrypted = Cryptor::Decrypt($encrypted, $key);
+
+echo "'$encrypted' => '$decrypted' (" . strlen($decrypted) . ")\n";
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ associated data can be retrieved.
 Require this library through composer:
 
 ```
-composer require pensiero/php-openssl-cryptor
+composer require ioncube/php-openssl-cryptor
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,15 @@
 {
-    "name": "ioncube/php-openssl-cryptor",
+    "name": "pensiero/php-openssl-cryptor",
     "description": "Simple to use class for encrypting/decrypting using the PHP Openssl library.",
     "type": "library",
     "license": "MIT",
     "require": {
+        "php": ">=5.6",
         "ext-openssl": "*"
     },
     "autoload": {
       "psr-4": {
-        "ioncube\\phpOpensslCryptor\\": "src/"
+        "OpensslCryptor\\": "src/"
       }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pensiero/php-openssl-cryptor",
+    "name": "ioncube/php-openssl-cryptor",
     "description": "Simple to use class for encrypting/decrypting using the PHP Openssl library.",
     "type": "library",
     "license": "MIT",

--- a/examples/example.php
+++ b/examples/example.php
@@ -1,5 +1,7 @@
 <?php
 
+require __DIR__ . '../vendor/autoload.php';
+
 use OpensslCryptor\Cryptor;
 
 $data = 'Good things come in small packages.';

--- a/examples/example.php
+++ b/examples/example.php
@@ -1,6 +1,6 @@
 <?php
 
-use ioncube\phpOpensslCryptor\Cryptor;
+use OpensslCryptor\Cryptor;
 
 $data = 'Good things come in small packages.';
 $key = '9901:io=[<>602vV03&Whb>9J&M~Oq';

--- a/src/Cryptor.php
+++ b/src/Cryptor.php
@@ -57,12 +57,12 @@ class Cryptor
 
         if (!in_array($cipher_algo, openssl_get_cipher_methods(true), false))
         {
-            throw new UnknownAlgoException("Cryptor:: - unknown cipher algo {$cipher_algo}");
+            throw new UnknownAlgoException("Unknown cipher algo {$cipher_algo}");
         }
 
         if (!in_array($hash_algo, openssl_get_md_methods(true), false))
         {
-            throw new UnknownAlgoException("Cryptor:: - unknown hash algo {$hash_algo}");
+            throw new UnknownAlgoException("Unknown hash algo {$hash_algo}");
         }
 
         $this->iv_num_bytes = openssl_cipher_iv_length($cipher_algo);

--- a/src/Cryptor.php
+++ b/src/Cryptor.php
@@ -55,12 +55,12 @@ class Cryptor
         $this->hash_algo = $hash_algo;
         $this->format = $fmt;
 
-        if (!in_array($cipher_algo, openssl_get_cipher_methods(true)))
+        if (!in_array($cipher_algo, openssl_get_cipher_methods(true), false))
         {
             throw new UnknownAlgoException("Cryptor:: - unknown cipher algo {$cipher_algo}");
         }
 
-        if (!in_array($hash_algo, openssl_get_md_methods(true)))
+        if (!in_array($hash_algo, openssl_get_md_methods(true), false))
         {
             throw new UnknownAlgoException("Cryptor:: - unknown hash algo {$hash_algo}");
         }
@@ -88,7 +88,7 @@ class Cryptor
         // Build an initialisation vector
         $iv = openssl_random_pseudo_bytes($this->iv_num_bytes, $isStrongCrypto);
         if (!$isStrongCrypto) {
-            throw new UnexpectedResultException("Not a strong key");
+            throw new UnexpectedResultException('Not a strong key');
         }
 
         // Hash the key
@@ -107,11 +107,11 @@ class Cryptor
         $res = $iv . $encrypted;
 
         // and format the result if required.
-        if ($fmt == Cryptor::FORMAT_B64)
+        if ($fmt === self::FORMAT_B64)
         {
             $res = base64_encode($res);
         }
-        else if ($fmt == Cryptor::FORMAT_HEX)
+        else if ($fmt === self::FORMAT_HEX)
         {
             $res = unpack('H*', $res)[1];
         }
@@ -139,11 +139,11 @@ class Cryptor
         $raw = $in;
 
         // Restore the encrypted data if encoded
-        if ($fmt == Cryptor::FORMAT_B64)
+        if ($fmt === self::FORMAT_B64)
         {
             $raw = base64_decode($in);
         }
-        else if ($fmt == Cryptor::FORMAT_HEX)
+        else if ($fmt === self::FORMAT_HEX)
         {
             $raw = pack('H*', $in);
         }

--- a/src/Cryptor.php
+++ b/src/Cryptor.php
@@ -87,8 +87,15 @@ class Cryptor
 
         // Build an initialisation vector
         $iv = openssl_random_pseudo_bytes($this->iv_num_bytes, $isStrongCrypto);
-        if (!$isStrongCrypto) {
+
+        // key is not strong enough
+        if ($isStrongCrypto === false) {
             throw new UnexpectedResultException('Not a strong key');
+        }
+
+        // failure during initialisation
+        if ($iv === false) {
+            throw new UnexpectedResultException('Failure while initializing the pseudo-random string of bytes');
         }
 
         // Hash the key

--- a/src/Cryptor.php
+++ b/src/Cryptor.php
@@ -57,12 +57,12 @@ class Cryptor
 
         if (!in_array($cipher_algo, openssl_get_cipher_methods(true), false))
         {
-            throw new UnknownAlgoException("Unknown cipher algo {$cipher_algo}");
+            throw new UnknownAlgoException('Unknown cipher algo ' . $cipher_algo);
         }
 
         if (!in_array($hash_algo, openssl_get_md_methods(true), false))
         {
-            throw new UnknownAlgoException("Unknown hash algo {$hash_algo}");
+            throw new UnknownAlgoException('Unknown hash algo ' . $hash_algo);
         }
 
         $this->iv_num_bytes = openssl_cipher_iv_length($cipher_algo);
@@ -158,7 +158,7 @@ class Cryptor
         // and do an integrity check on the size.
         if (strlen($raw) < $this->iv_num_bytes)
         {
-            throw new UnexpectedResultException('Data length ' . strlen($raw) . " is less than iv length {$this->iv_num_bytes}");
+            throw new UnexpectedResultException('Data length ' . strlen($raw) . ' is less than iv length ' . $this->iv_num_bytes);
         }
 
         // Extract the initialisation vector and encrypted data

--- a/src/Cryptor.php
+++ b/src/Cryptor.php
@@ -23,7 +23,7 @@
  * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace ioncube\phpOpensslCryptor;
+namespace OpensslCryptor;
 
 class Cryptor
 {

--- a/src/Exception/ProcessException.php
+++ b/src/Exception/ProcessException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpensslCryptor\Exception;
+
+class ProcessException extends \Exception
+{
+
+}

--- a/src/Exception/UnexpectedResultException.php
+++ b/src/Exception/UnexpectedResultException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpensslCryptor\Exception;
+
+class UnexpectedResultException extends \Exception
+{
+
+}

--- a/src/Exception/UnknownAlgoException.php
+++ b/src/Exception/UnknownAlgoException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpensslCryptor\Exception;
+
+class UnknownAlgoException extends \Exception
+{
+
+}

--- a/tests/BasicCryptTest.php
+++ b/tests/BasicCryptTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require __DIR__ . '../vendor/autoload.php';
+
 use OpensslCryptor\Cryptor;
 
 $data = 'Good things come in small packages.';

--- a/tests/BasicCryptTest.php
+++ b/tests/BasicCryptTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use ioncube\phpOpensslCryptor\Cryptor;
+use OpensslCryptor\Cryptor;
 
 $data = 'Good things come in small packages.';
 $key = '9901:io=[<>602vV03&Whb>9J&M~Oq';


### PR DESCRIPTION
Thanks to this PR, users will be able to import your library inside their project thanks to composer and packagist.

In case you approve the PR, you should also create a release (here on GitHub) and submit your repo to [packagist.org](https://packagist.org/). I [already did this with my repo](https://packagist.org/packages/pensiero/php-openssl-cryptor), in order to use it in my projects. In case I can remove it.

Some extra contained in this repo:
- Added custom exceptions
- Code cleaned and updated (thanks to [PHP Inspections plugin](https://plugins.jetbrains.com/plugin/7622-php-inspections-ea-extended-))
- Simplified the namespace (`OpensslCryptor` instead of `ioncube\phpOpensslCryptor`); I referred to standard conventions that are widely used around open source PHP projects on GitHub (camelcase and only one word); moreover i stripped the word `php`, that is not useful (we are working within a php environment); if you don't like it, and you prefer something else, don't hesitate to tell me

Fixes #9 